### PR TITLE
SourceFile criteria + UnresolvedReferences criteria

### DIFF
--- a/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
@@ -37,7 +37,7 @@ public class SourceFile extends Criterion {
     }
 
     private boolean matchesGlobAndContent(Path path) {
-        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + globPattern);
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**/" + globPattern);
         if (matcher.matches(path)) {
             if (contentToSearch != null) {
                 try {

--- a/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
@@ -1,0 +1,54 @@
+package com.github.sulir.jamabuild.criteria;
+
+import com.github.sulir.jamabuild.Project;
+import com.github.sulir.jamabuild.filtering.AllowedPhases;
+import com.github.sulir.jamabuild.filtering.Criterion;
+import org.apache.commons.io.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.stream.Stream;
+
+@AllowedPhases(Criterion.Phase.PRE_BUILD)
+public class SourceFile extends Criterion {
+    private final String globPattern;
+    private final String contentToSearch;
+
+    public SourceFile(Phase phase, Type type, String globPattern) {
+        super(phase, type);
+        this.globPattern = globPattern;
+        this.contentToSearch = null;
+    }
+
+    public SourceFile(Phase phase, Type type, String globPattern, String contentToSearch) {
+        super(phase, type);
+        this.globPattern = globPattern;
+        this.contentToSearch = contentToSearch;
+    }
+
+    @Override
+    public boolean isMet(Project project) {
+        try (Stream<Path> paths = Files.walk(project.getSourceDir())) {
+            return paths.anyMatch(path -> matchesGlobAndContent(path));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private boolean matchesGlobAndContent(Path path) {
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + globPattern);
+        if (matcher.matches(path)) {
+            if (contentToSearch != null) {
+                try {
+                    return FileUtils.readFileToString(path.toFile(), "UTF-8").contains(contentToSearch);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
@@ -14,16 +14,11 @@ public class SourceFile extends Criterion {
     private final String globPattern;
     private final String contentToSearch;
 
-    public SourceFile(Phase phase, Type type, String globPattern) {
+    public SourceFile(Phase phase, Type type, String parameter) {
         super(phase, type);
-        this.globPattern = globPattern;
-        this.contentToSearch = null;
-    }
-
-    public SourceFile(Phase phase, Type type, String globPattern, String contentToSearch) {
-        super(phase, type);
-        this.globPattern = globPattern;
-        this.contentToSearch = contentToSearch;
+        String[] parameters = parameter.split(" ", 2);
+        this.globPattern = parameters[0];
+        this.contentToSearch = parameters.length > 1 ? parameters[1] : null;;
     }
 
     @Override

--- a/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
@@ -29,7 +29,7 @@ public class SourceFile extends Criterion {
     @Override
     public boolean isMet(Project project) {
         try (Stream<Path> paths = Files.walk(project.getSourceDir())) {
-            return paths.anyMatch(path -> matchesGlobAndContent(path));
+            return paths.anyMatch(this::matchesGlobAndContent);
         } catch (IOException e) {
             e.printStackTrace();
             return false;

--- a/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/SourceFile.java
@@ -18,7 +18,7 @@ public class SourceFile extends Criterion {
         super(phase, type);
         String[] parameters = parameter.split(" ", 2);
         this.globPattern = parameters[0];
-        this.contentToSearch = parameters.length > 1 ? parameters[1] : null;;
+        this.contentToSearch = parameters.length > 1 ? parameters[1] : null;
     }
 
     @Override

--- a/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
@@ -10,6 +10,8 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @AllowedPhases(Criterion.Phase.POST_BUILD)
@@ -24,16 +26,11 @@ public class UnresolvedReferences extends Criterion {
         Path jarsDir = project.getJARsDir();
 
         try (Stream<Path> paths = Files.walk(jarsDir)) {
-            return paths.anyMatch(this::hasUnresolvedReferences);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return false;
-        }
-    }
-
-    private boolean hasUnresolvedReferences(Path pathToJarFile) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder(Arrays.asList("jdeps", "-R", pathToJarFile.toString()));
+            List<String> jdepsCommand = Arrays.asList("jdeps", "-R");
+            List<String> jarFiles = paths.map(Path::toString).collect(Collectors.toList());
+            jdepsCommand.addAll(jarFiles);
+            System.out.println(">>>> " + jdepsCommand);
+            ProcessBuilder pb = new ProcessBuilder(jdepsCommand);
             Process p = pb.start();
             p.waitFor();
 
@@ -48,7 +45,6 @@ public class UnresolvedReferences extends Criterion {
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
-
         return false;
     }
 }

--- a/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
@@ -1,0 +1,43 @@
+package com.github.sulir.jamabuild.criteria;
+
+import com.github.sulir.jamabuild.Project;
+import com.github.sulir.jamabuild.filtering.AllowedPhases;
+import com.github.sulir.jamabuild.filtering.Criterion;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+@AllowedPhases(Criterion.Phase.POST_BUILD)
+public class UnresolvedReferences extends Criterion {
+
+    public UnresolvedReferences(Phase phase, Type type) {
+        super(phase, type);
+    }
+
+    @Override
+    public boolean isMet(Project project) {
+        Path jarsDir = project.getJARsDir();
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder(Arrays.asList("jdeps", "-verbose", "-R", jarsDir.toString()));
+            Process p = pb.start();
+            p.waitFor();
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains("not found")) {
+                    return true;
+                }
+            }
+            br.close();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @AllowedPhases(Criterion.Phase.POST_BUILD)
@@ -20,14 +19,14 @@ public class UnresolvedReferences extends Criterion {
         super(phase, type);
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public boolean isMet(Project project) {
         Path jarsDir = project.getJARsDir();
 
-        List<String> jdepsCommand = new ArrayList<String>();
-        jdepsCommand.addAll(Arrays.asList("jdeps", "-R"));
+        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-R"));
         try (Stream<Path> paths = Files.walk(jarsDir).filter(Files::isRegularFile)) {
-            jdepsCommand.addAll(paths.map(Path::toString).collect(Collectors.toList()));
+            jdepsCommand.addAll(paths.map(Path::toString).toList());
 
             ProcessBuilder pb = new ProcessBuilder(jdepsCommand);
             // using this temp file to prevent hanging on full output stream

--- a/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
@@ -28,8 +28,7 @@ public class UnresolvedReferences extends Criterion {
         String javaVersion = System.getProperty("java.version");
         String majorVersion = javaVersion.startsWith("1.") ? javaVersion.substring(2, 3) : javaVersion.split("\\.")[0];
 
-
-        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-summary" ,"--multi-release", majorVersion, "-recursive", "--module-path", depsDir.toString()));
+        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-summary", "--ignore-missing-deps", "--multi-release", majorVersion, "-recursive", "--module-path", depsDir.toString()));
         try (Stream<Path> pathsJars = Files.walk(jarsDir)
                 .filter(Files::isRegularFile)
                 .filter(p -> p.toString().toLowerCase().endsWith(".jar"));

--- a/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
@@ -28,7 +28,8 @@ public class UnresolvedReferences extends Criterion {
         String javaVersion = System.getProperty("java.version");
         String majorVersion = javaVersion.startsWith("1.") ? javaVersion.substring(2, 3) : javaVersion.split("\\.")[0];
 
-        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-summary", "--ignore-missing-deps", "--multi-release", majorVersion, "-recursive", "--module-path", depsDir.toString()));
+        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-summary", "--ignore-missing-deps",
+                "--multi-release", majorVersion, "-recursive", "--module-path", depsDir.toString()));
         try (Stream<Path> pathsJars = Files.walk(jarsDir)
                 .filter(Files::isRegularFile)
                 .filter(p -> p.toString().toLowerCase().endsWith(".jar"));

--- a/src/main/java/com/github/sulir/jamabuild/filtering/CriterionFactory.java
+++ b/src/main/java/com/github/sulir/jamabuild/filtering/CriterionFactory.java
@@ -2,6 +2,7 @@ package com.github.sulir.jamabuild.filtering;
 
 import com.github.sulir.jamabuild.criteria.AndroidSource;
 import com.github.sulir.jamabuild.criteria.BashScript;
+import com.github.sulir.jamabuild.criteria.SourceFile;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -10,7 +11,8 @@ import java.util.List;
 public class CriterionFactory {
     private static final List<Class<? extends Criterion>> criteria = List.of(
             AndroidSource.class,
-            BashScript.class);
+            BashScript.class,
+            SourceFile.class);
     private final Criterion.Phase phase;
     private final Criterion.Type type;
 

--- a/src/main/java/com/github/sulir/jamabuild/filtering/CriterionFactory.java
+++ b/src/main/java/com/github/sulir/jamabuild/filtering/CriterionFactory.java
@@ -3,6 +3,7 @@ package com.github.sulir.jamabuild.filtering;
 import com.github.sulir.jamabuild.criteria.AndroidSource;
 import com.github.sulir.jamabuild.criteria.BashScript;
 import com.github.sulir.jamabuild.criteria.SourceFile;
+import com.github.sulir.jamabuild.criteria.UnresolvedReferences;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -12,7 +13,8 @@ public class CriterionFactory {
     private static final List<Class<? extends Criterion>> criteria = List.of(
             AndroidSource.class,
             BashScript.class,
-            SourceFile.class);
+            SourceFile.class,
+            UnresolvedReferences.class);
     private final Criterion.Phase phase;
     private final Criterion.Type type;
 


### PR DESCRIPTION
Adds SourceFile criteria which allows testing source files presence using glob in pre build phase.

Also adds UnresolvedReferences criterion which attempts to search for "not found" text in output of jdeps tool run on JARs folder of the project in post build phase.