### PR TITLE
Building state for tracking progress of built projects

### DIFF
--- a/src/main/java/com/github/sulir/jamabuild/Main.java
+++ b/src/main/java/com/github/sulir/jamabuild/Main.java
@@ -2,6 +2,7 @@ package com.github.sulir.jamabuild;
 
 import com.github.sulir.jamabuild.processes.ConsoleProcess;
 import com.github.sulir.jamabuild.processes.ProcessList;
+import com.github.sulir.jamabuild.processes.BuildingState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,7 +22,8 @@ public class Main {
 
         ProcessList processList = new ProcessList(rootDirectory);
         processList.addProjects(Path.of(rootDirectory, PROJECTS_FILE));
-        processList.runAll();
+        BuildingState state = BuildingState.getBuildingStateFor(rootDirectory, processList, settings);
+        processList.runAll(state);
     }
 
     private static void updateDockerImage(Settings settings) {

--- a/src/main/java/com/github/sulir/jamabuild/Settings.java
+++ b/src/main/java/com/github/sulir/jamabuild/Settings.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
 
 public record Settings(
         String dockerImage,
@@ -68,5 +70,23 @@ public record Settings(
     @Override
     public String[] postExclude() {
         return postExclude == null ? new String[0] : postExclude;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Settings settings = (Settings) o;
+        return Objects.equals(dockerImage, settings.dockerImage) && Objects.equals(timeout, settings.timeout) && Objects.equals(skipTests, settings.skipTests) && Arrays.equals(preInclude, settings.preInclude) && Arrays.equals(preExclude, settings.preExclude) && Arrays.equals(postInclude, settings.postInclude) && Arrays.equals(postExclude, settings.postExclude);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(dockerImage, timeout, skipTests);
+        result = 31 * result + Arrays.hashCode(preInclude);
+        result = 31 * result + Arrays.hashCode(preExclude);
+        result = 31 * result + Arrays.hashCode(postInclude);
+        result = 31 * result + Arrays.hashCode(postExclude);
+        return result;
     }
 }

--- a/src/main/java/com/github/sulir/jamabuild/processes/BuildingState.java
+++ b/src/main/java/com/github/sulir/jamabuild/processes/BuildingState.java
@@ -1,0 +1,117 @@
+package com.github.sulir.jamabuild.processes;
+
+import com.github.sulir.jamabuild.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BuildingState {
+    private static final Logger log = LoggerFactory.getLogger(BuildingState.class);
+
+    private static final String FILE_NAME = ".state";
+
+    private final String rootDirectory;
+
+    private List<String> alreadyBuiltProjectsLines;
+
+    public BuildingState(String rootDirectory) {
+        this.rootDirectory = rootDirectory;
+        this.alreadyBuiltProjectsLines = new ArrayList<>();
+    }
+
+    public BuildingState(String rootDirectory, List<String> processedProjectsLines) {
+        this.rootDirectory = rootDirectory;
+        this.alreadyBuiltProjectsLines = new ArrayList<>(processedProjectsLines);
+    }
+
+    public boolean shouldSkipProject(DockerProcess process) {
+        String processLine = process.getProjectType() + "\t" + process.getProjectId();
+        if (!alreadyBuiltProjectsLines.isEmpty() && alreadyBuiltProjectsLines.get(0).equals(processLine)) {
+            alreadyBuiltProjectsLines.remove(0);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public void didBuildProject(DockerProcess process) {
+        String processLine = process.getProjectType() + "\t" + process.getProjectId();
+        Path stateFile = Path.of(rootDirectory, FILE_NAME);
+        try {
+            List<String> processLineToWrite = Arrays.asList(processLine);
+            Files.write(stateFile, processLineToWrite, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            // should we report this?
+        }
+    }
+
+    public void didBuildAllProjects() {
+        Path stateFile = Path.of(rootDirectory, FILE_NAME);
+        try {
+            Files.delete(stateFile);
+        } catch (IOException ex) {
+            // ignore
+        }
+    }
+
+    public static BuildingState getBuildingStateFor(String rootDirectory, ProcessList currentProcessList, Settings settings) {
+        int settingsHash = settings.hashCode();
+
+        Path stateFile = Path.of(rootDirectory, FILE_NAME);
+
+        try {
+            List<String> stateLines = Files.readAllLines(stateFile);
+            if (stateLines.size() > 1 // state file contains at least a single already built project
+                    && String.valueOf(settingsHash).equals(stateLines.get(0))) { // settings has to have the same hash
+                List<String> processedProjectsLines = stateLines.subList(1, stateLines.size());
+                if (isStateFileCompatibleWithCurrentProjectsConfiguration(processedProjectsLines, currentProcessList)) {
+                    return new BuildingState(rootDirectory, processedProjectsLines);
+                } else {
+                    return prepareEmptyStateFor(rootDirectory, settings);
+                }
+            } else {
+                return prepareEmptyStateFor(rootDirectory, settings);
+            }
+        } catch (IOException | SecurityException e) {
+            // assume broken or missing state, restart from scratch
+            return prepareEmptyStateFor(rootDirectory, settings);
+        }
+    }
+
+    private static BuildingState prepareEmptyStateFor(String rootDirectory, Settings settings) {
+        int settingsHash = settings.hashCode();
+        Path stateFile = Path.of(rootDirectory, FILE_NAME);
+        try {
+            List<String> settingsHashToWrite = Arrays.asList(String.valueOf(settingsHash));
+            Files.write(stateFile, settingsHashToWrite);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+        return new BuildingState(rootDirectory);
+    }
+
+    private static boolean isStateFileCompatibleWithCurrentProjectsConfiguration(List<String> processedProjectsLines, ProcessList currentProcessList) {
+        List<DockerProcess> currentProcesses = currentProcessList.getProcesses();
+        if (processedProjectsLines.isEmpty() || processedProjectsLines.size() >= currentProcesses.size()) {
+            return false;
+        }
+        // State file has to be a prefix of the projects configuration
+        for (int i = 0; i < processedProjectsLines.size(); i++) {
+            String[] processedProject = processedProjectsLines.get(i).split("\t");
+            String type = processedProject[0];
+            String id = processedProject[1];
+            DockerProcess ithProcess = currentProcesses.get(i);
+            if (!type.equals(ithProcess.getProjectType()) || !id.equals(ithProcess.getProjectId())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/github/sulir/jamabuild/processes/BuildingState.java
+++ b/src/main/java/com/github/sulir/jamabuild/processes/BuildingState.java
@@ -1,25 +1,21 @@
 package com.github.sulir.jamabuild.processes;
 
 import com.github.sulir.jamabuild.Settings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class BuildingState {
-    private static final Logger log = LoggerFactory.getLogger(BuildingState.class);
 
     private static final String FILE_NAME = ".state";
 
     private final String rootDirectory;
 
-    private List<String> alreadyBuiltProjectsLines;
+    private final List<String> alreadyBuiltProjectsLines;
 
     public BuildingState(String rootDirectory) {
         this.rootDirectory = rootDirectory;
@@ -45,8 +41,7 @@ public class BuildingState {
         String processLine = process.getProjectType() + "\t" + process.getProjectId();
         Path stateFile = Path.of(rootDirectory, FILE_NAME);
         try {
-            List<String> processLineToWrite = Arrays.asList(processLine);
-            Files.write(stateFile, processLineToWrite, StandardOpenOption.APPEND);
+            Files.write(stateFile, List.of(processLine), StandardOpenOption.APPEND);
         } catch (IOException e) {
             // should we report this?
         }
@@ -61,7 +56,9 @@ public class BuildingState {
         }
     }
 
-    public static BuildingState getBuildingStateFor(String rootDirectory, ProcessList currentProcessList, Settings settings) {
+    public static BuildingState getBuildingStateFor(String rootDirectory,
+                                                    ProcessList currentProcessList,
+                                                    Settings settings) {
         int settingsHash = settings.hashCode();
 
         Path stateFile = Path.of(rootDirectory, FILE_NAME);
@@ -89,15 +86,15 @@ public class BuildingState {
         int settingsHash = settings.hashCode();
         Path stateFile = Path.of(rootDirectory, FILE_NAME);
         try {
-            List<String> settingsHashToWrite = Arrays.asList(String.valueOf(settingsHash));
-            Files.write(stateFile, settingsHashToWrite);
+            Files.write(stateFile, List.of(String.valueOf(settingsHash)));
         } catch (IOException ex) {
             ex.printStackTrace();
         }
         return new BuildingState(rootDirectory);
     }
 
-    private static boolean isStateFileCompatibleWithCurrentProjectsConfiguration(List<String> processedProjectsLines, ProcessList currentProcessList) {
+    private static boolean isStateFileCompatibleWithCurrentProjectsConfiguration(List<String> processedProjectsLines,
+                                                                                 ProcessList currentProcessList) {
         List<DockerProcess> currentProcesses = currentProcessList.getProcesses();
         if (processedProjectsLines.isEmpty() || processedProjectsLines.size() >= currentProcesses.size()) {
             return false;

--- a/src/main/java/com/github/sulir/jamabuild/processes/DockerProcess.java
+++ b/src/main/java/com/github/sulir/jamabuild/processes/DockerProcess.java
@@ -20,6 +20,10 @@ public class DockerProcess {
         return projectId;
     }
 
+    public String getProjectType() {
+        return type;
+    }
+
     public void run() {
         if (System.getenv("JAMABUILD_NO_DOCKER") == null) {
             executeDocker();

--- a/src/main/java/com/github/sulir/jamabuild/processes/ProcessList.java
+++ b/src/main/java/com/github/sulir/jamabuild/processes/ProcessList.java
@@ -33,10 +33,20 @@ public class ProcessList {
         }
     }
 
-    public void runAll() {
+    public List<DockerProcess> getProcesses() {
+        return processes;
+    }
+
+    public void runAll(BuildingState state) {
         for (DockerProcess process : processes) {
-            log.info("Project {}", process.getProjectId());
-            process.run();
+            if (state.shouldSkipProject(process)) {
+                log.info("Skipping project {} as it was built in previous session", process.getProjectId());
+            } else {
+                log.info("Project {}", process.getProjectId());
+                process.run();
+                state.didBuildProject(process);
+            }
         }
+        state.didBuildAllProjects();
     }
 }


### PR DESCRIPTION
Added BuildingState which tracks which projects are built during a JaMaBuild run in a .state file in root directory.

.state file starts with a Settings hash on a separate line (changing settings assumes a new run that should not resume a previous one). Then there is a single line with a project type and its id separated by a tab for each project that was already built in an ongoing or previously unfinished JamaBuild run. Once the JaMaBuild successfully runs all the projects builds, the .state file is removed.

If there is a .state file when JaMaBuild starts, it means previous run was abruptly finished and some of the projects were not built. When preparing state, we try to read the .state file, first check whether the settings are the same as they were before by comparing the hash saved in .state file. Then we compare all the following lines of the already built projects with the projects.tsv file to see if there was any change in the part of the projects that were already built - if there was a change, we restart the whole process.