### PR TITLE
Check jar and deps folders before looking for unresolved dependencies

### DIFF
--- a/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
+++ b/src/main/java/com/github/sulir/jamabuild/criteria/UnresolvedReferences.java
@@ -19,52 +19,80 @@ public class UnresolvedReferences extends Criterion {
         super(phase, type);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public boolean isMet(Project project) {
         Path jarsDir = project.getJARsDir();
-        Path depsDir = project.getDependenciesDir();
+        Path dependenciesDir = project.getDependenciesDir();
 
-        String javaVersion = System.getProperty("java.version");
-        String majorVersion = javaVersion.startsWith("1.") ? javaVersion.substring(2, 3) : javaVersion.split("\\.")[0];
+        if (Files.exists(jarsDir)) {
+            if (Files.exists(dependenciesDir)) {
+                try (Stream<Path> jarsPaths = Files.walk(jarsDir)
+                        .filter(Files::isRegularFile)
+                        .filter(p -> p.toString().toLowerCase().endsWith(".jar"));
+                     Stream<Path> dependenciesPaths = Files.walk(dependenciesDir)
+                             .filter(Files::isRegularFile)
+                             .filter(p -> p.toString().toLowerCase().endsWith(".jar"))) {
+                    List<String> allJarFiles = Stream.concat(jarsPaths, dependenciesPaths)
+                            .map(Path::toString)
+                            .toList();
 
-        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-summary", "--ignore-missing-deps",
-                "--multi-release", majorVersion, "-recursive", "--module-path", depsDir.toString()));
-        try (Stream<Path> pathsJars = Files.walk(jarsDir)
-                .filter(Files::isRegularFile)
-                .filter(p -> p.toString().toLowerCase().endsWith(".jar"));
-             Stream<Path> pathsDeps = Files.walk(depsDir)
-                     .filter(Files::isRegularFile)
-                     .filter(p -> p.toString().toLowerCase().endsWith(".jar"))) {
-            List<String> allJarFiles = Stream.concat(pathsJars, pathsDeps)
-                    .map(Path::toString)
-                    .toList();
+                    return hasUnresolvedReferencesInJARs(allJarFiles, dependenciesDir, project);
+                } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                try (Stream<Path> jarsPaths = Files.walk(jarsDir)
+                        .filter(Files::isRegularFile)
+                        .filter(p -> p.toString().toLowerCase().endsWith(".jar"))) {
+                    List<String> allJarFiles = jarsPaths
+                            .map(Path::toString)
+                            .toList();
 
-            jdepsCommand.addAll(allJarFiles);
-
-            ProcessBuilder pb = new ProcessBuilder(jdepsCommand);
-            // using this temp file to prevent hanging on full output stream
-            File outputFile = project.getDirectory().resolve("processOutput.txt").toFile();
-            pb.redirectOutput(outputFile);
-            pb.redirectError(outputFile);
-            Process p = pb.start();
-            p.waitFor();
-
-            BufferedReader reader = new BufferedReader(new FileReader(outputFile));
-            String line;
-            while ((line = reader.readLine()) != null) {
-                if (line.contains("not found")) {
-                    reader.close();
-                    outputFile.delete();
-                    return true;
+                    return hasUnresolvedReferencesInJARs(allJarFiles, null, project);
+                } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
                 }
             }
-
-            reader.close();
-            outputFile.delete();
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
         }
+        return false;
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private boolean hasUnresolvedReferencesInJARs(List<String> allJarFiles,
+                                                  Path dependenciesDir,
+                                                  Project project) throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        String majorVersion = javaVersion.startsWith("1.")
+                ? javaVersion.substring(2, 3)
+                : javaVersion.split("\\.")[0];
+
+        List<String> jdepsCommand = new ArrayList<>(Arrays.asList("jdeps", "-summary", "--ignore-missing-deps",
+                "--multi-release", majorVersion, "-recursive"));
+        if (dependenciesDir != null) {
+            jdepsCommand.addAll(List.of("--module-path", dependenciesDir.toString()));
+        }
+        jdepsCommand.addAll(allJarFiles);
+
+        ProcessBuilder pb = new ProcessBuilder(jdepsCommand);
+        // using this temp file to prevent hanging on full output stream
+        File outputFile = project.getDirectory().resolve("processOutput.txt").toFile();
+        pb.redirectOutput(outputFile);
+        pb.redirectError(outputFile);
+        Process p = pb.start();
+        p.waitFor();
+
+        BufferedReader reader = new BufferedReader(new FileReader(outputFile));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.contains("not found")) {
+                reader.close();
+                outputFile.delete();
+                return true;
+            }
+        }
+
+        reader.close();
+        outputFile.delete();
         return false;
     }
 }


### PR DESCRIPTION
Before walking the jars and deps folders, we can check for their existence to prevent "crashing" the UnresolvedReferences criterion.